### PR TITLE
chore: replace npm install with npm ci

### DIFF
--- a/examples/hello-world/Dockerfile
+++ b/examples/hello-world/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Replace `npm install` / `npm i` with `npm ci` for deterministic, clean installs based on lockfile
- Affects Dockerfiles, docker-compose files, Jenkinsfiles, and shell scripts

## Test plan
- [ ] Verify CI/CD pipelines run successfully with `npm ci`
- [ ] Ensure `package-lock.json` exists in relevant directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)